### PR TITLE
Add signature and archiver verification in refuteLostArchiverRoute

### DIFF
--- a/src/p2p/LostArchivers/functions.ts
+++ b/src/p2p/LostArchivers/functions.ts
@@ -28,7 +28,6 @@ import {
   serializeLostArchiverInvestigateReq,
 } from '../../types/LostArchiverInvestigateReq'
 import { InternalRouteEnum } from '../../types/enum/InternalRouteEnum'
-import { tellBinary } from '../Comms'
 
 /** Lost Archivers Functions */
 
@@ -180,10 +179,10 @@ export function informInvestigator(target: publicKey): void {
 
     // Send message to investigator
     info(`informInvestigator: sending InvestigateArchiverMsg: ${inspect(investigateMsg)}`)
-    if (this.config.p2p.useBinarySerializedEndpoints && this.config.p2p.lostArchiverInvestigateBinary) {
+    if (Context.config.p2p.useBinarySerializedEndpoints && Context.config.p2p.lostArchiverInvestigateBinary) {
       Comms.tellBinary<LostArchiverInvestigateReq>(
         [investigator],
-        InternalRouteEnum.binary_broadcast_state,
+        InternalRouteEnum.binary_lost_archiver_investigate,
         investigateMsg,
         serializeLostArchiverInvestigateReq,
         {}

--- a/src/p2p/LostArchivers/functions.ts
+++ b/src/p2p/LostArchivers/functions.ts
@@ -144,15 +144,16 @@ export function getInvestigator(target: publicKey, marker: CycleMarker): Node {
   if (idx < 0) idx = (-1 - idx) % activeByIdOrder.length
   // eslint-disable-next-line security/detect-object-injection
   let foundNode = activeByIdOrder[idx]
+  if (foundNode == null || foundNode.id === id) {
+    // skip to next node if the selected node is null or youself
+    idx = (idx + 1) % activeByIdOrder.length
+    // eslint-disable-next-line security/detect-object-injection
+    foundNode = activeByIdOrder[idx]
+  }
   // eslint-disable-next-line security/detect-object-injection
   if (foundNode == null) {
     throw new Error(`activeByIdOrder idx:${idx} length: ${activeByIdOrder.length}`)
   }
-  if (foundNode.id === id) {
-    idx = (idx + 1) % activeByIdOrder.length
-    // eslint-disable-next-line security/detect-object-injection
-    foundNode = activeByIdOrder[idx]
-  } // skip to next node if the selected node is target
   return foundNode
 }
 

--- a/src/p2p/LostArchivers/index.ts
+++ b/src/p2p/LostArchivers/index.ts
@@ -120,7 +120,7 @@ export function updateRecord(
 
   // add all txs.lostArchivers publicKeys to record.lostArchivers
   for (const tx of txs.lostArchivers) {
-    const target = tx.investigateMsg?.target
+    const target = tx?.investigateMsg?.target
     if(target) {
       insertSorted(lostArchivers, target)
     } else {
@@ -129,7 +129,7 @@ export function updateRecord(
   }
   // add all txs.refutedArchivers publicKeys to record.refutedArchivers
   for (const tx of txs.refutedArchivers) {
-    const target = tx.downMsg?.investigateMsg?.target
+    const target = tx?.downMsg?.investigateMsg?.target
     if(target) {
       insertSorted(refutedArchivers, target)
     } else {

--- a/src/p2p/LostArchivers/routes.ts
+++ b/src/p2p/LostArchivers/routes.ts
@@ -65,8 +65,19 @@ const lostArchiverUpGossip: GossipHandler<SignedObject<ArchiverUpMsg>, Node['id'
   }
 
   const upMsg = payload as SignedObject<ArchiverUpMsg>
-  const target = upMsg.downMsg.investigateMsg.target
+  const target = upMsg?.downMsg?.investigateMsg?.target
   // to-do: check target is a string or hexstring and min length
+  if (!target) {
+    logging.warn(`lostArchiverUpGossip: missing target in upMsg: ${inspect(upMsg)}`)
+    return
+  }
+
+  // verify refute crypto token
+  if (!crypto.verify(upMsg.refuteMsg, upMsg.refuteMsg.archiver)) {
+    console.log(':>> invalid signature in lostArchiverUpGossip')
+    return 'invalid signature'
+  }
+
   const record = lostArchiversMap.get(target)
   if (!record) {
     // nothing to do

--- a/src/p2p/LostArchivers/routes.ts
+++ b/src/p2p/LostArchivers/routes.ts
@@ -200,7 +200,7 @@ const investigateLostArchiverRouteBinary: Route<InternalBinaryHandler<Buffer>> =
     profilerInstance.scopedProfileSectionStart(route, false, payload.length)
 
     try {
-      const reqStream = getStreamWithTypeCheck(payload, TypeIdentifierEnum.cGetAccountDataReq)
+      const reqStream = getStreamWithTypeCheck(payload, TypeIdentifierEnum.cLostArchiverInvestigateReq)
       if (!reqStream) {
         nestedCountersInstance.countEvent('internal', `${route}-invalid_request`)
         logging.warn(`${route}: Invalid request stream`)

--- a/src/p2p/LostArchivers/routes.ts
+++ b/src/p2p/LostArchivers/routes.ts
@@ -268,7 +268,9 @@ const refuteLostArchiverRoute: P2P.P2PTypes.Route<Handler> = {
       res.send(safeStringify({ status: 'failure', message: error }))
       return
     }
-    const refuteMsg = req.body as SignedObject<ArchiverRefutesLostMsg>
+
+    const { archiver, cycle, sign } = req.body
+    const refuteMsg: SignedObject<ArchiverRefutesLostMsg> = { archiver, cycle, sign }
     const target = refuteMsg.archiver
     // to-do: check target is a string or hexstring and min length
     let record = lostArchiversMap.get(target)


### PR DESCRIPTION
https://linear.app/shm/issue/BLUE-21/bug-when-submitting-the-lost-archiver-refute-request-causing-a-fatal

Summary:

- Safe access to nested object properties of `txs` in UpdateRecord function to prevent potential errors.
- Add signature verification in refuteLostArchiverRoute
- Add archiver verification in refuteLostArchiverRoute